### PR TITLE
リリース情報自動取得対象のリポジトリ一覧を README へ出力する

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 iOS Osushi が GitHub 上の各リポジトリのリリース情報を定期的に、自動で取得するために使用するツールです。
 
-## 動作環境
-macOS 10.15 以降の CLI および Linux の CLI で、Swift 5.6 以降。
-
-GitHub Actions で定期実行し、リリース情報を Slack Webhook に送信することを想定しています。
-
 ## リリース情報自動取得対象のリポジトリ
-リリース情報を自動で取得する先のリポジトリは、`ReleaseSubscriptions.yml` に列挙されています。
+<!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->
+<!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->
+
+なお、これらは `ReleaseSubscriptions.yml` に列挙されています。
 
 - `kind`: Slack Webhook URL の向き先を指定
   - `primary`（主としてオーナーが Apple のリポジトリ）
@@ -27,3 +25,8 @@ GitHub Actions で定期実行し、リリース情報を Slack Webhook に送�
 1. `kind` が `primary` → `secondary` の順
 1. `owner` の大文字小文字区別なし昇順
 1. `repo` の大文字小文字区別なし昇順
+
+## 動作環境
+macOS 10.15 以降の CLI および Linux の CLI で、Swift 5.6 以降。
+
+GitHub Actions で定期実行し、リリース情報を Slack Webhook に送信することを想定しています。

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ iOS Osushi が GitHub 上の各リポジトリのリリース情報を定期的�
 <!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->
 <!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->
 
-なお、これらは `ReleaseSubscriptions.yml` に列挙されています。
+この表は [ReleaseSubscriptions.yml](./ReleaseSubscriptions.yml) から自動で生成しています。
 
 - `kind`: Slack Webhook URL の向き先を指定
   - `primary`（主としてオーナーが Apple のリポジトリ）

--- a/Sources/ReleaseSubscriptions/App.swift
+++ b/Sources/ReleaseSubscriptions/App.swift
@@ -28,6 +28,7 @@ struct App: AsyncParsableCommand {
         let updatedContents = DifferenceComparator.insertions(repositories: repositories, old: oldContents, new: combinedContents)
         try await SlackNotifier.notify(to: slackURLs(), updates: updatedContents)
         try FileHelper.save(contents: combinedContents)
+        try Parser.writeToREADME(repositories: repositories)
     }
     
     private func slackURLs() -> [SlackWebhookDestination : URL] {

--- a/Sources/ReleaseSubscriptions/App.swift
+++ b/Sources/ReleaseSubscriptions/App.swift
@@ -28,7 +28,7 @@ struct App: AsyncParsableCommand {
         let updatedContents = DifferenceComparator.insertions(repositories: repositories, old: oldContents, new: combinedContents)
         try await SlackNotifier.notify(to: slackURLs(), updates: updatedContents)
         try FileHelper.save(contents: combinedContents)
-        try Parser.writeToREADME(repositories: repositories)
+        try FileHelper.writeToREADME(repositories: repositories)
     }
     
     private func slackURLs() -> [SlackWebhookDestination : URL] {

--- a/Sources/ReleaseSubscriptionsCore/Extension.swift
+++ b/Sources/ReleaseSubscriptionsCore/Extension.swift
@@ -10,6 +10,13 @@ import Foundation
 import FoundationNetworking
 #endif
 
+public extension URL {
+    static let topLevelDirectory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
 public extension URLSession {
     func data(from url: URL) async throws -> (Data, URLResponse) {
         let request = URLRequest(url: url)

--- a/Sources/ReleaseSubscriptionsCore/FileHelper.swift
+++ b/Sources/ReleaseSubscriptionsCore/FileHelper.swift
@@ -11,6 +11,10 @@ import FoundationNetworking
 #endif
 
 public struct FileHelper {
+    enum Error: Swift.Error {
+        case invalidREADMEFormat
+    }
+    
     static let RFC3339DateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -44,6 +48,8 @@ public struct FileHelper {
         }
     }
     
+    // MARK: - Repositories and Releases
+    
     public static func load(repositories: [GitHubRepository]) throws -> [GitHubRepository : [Release]] {
         var contents: [GitHubRepository : [Release]] = [:]
         for repository in repositories {
@@ -67,5 +73,37 @@ public struct FileHelper {
             let data = try encoder.encode(releases)
             try data.write(to: url)
         }
+    }
+    
+    
+    // MARK: - README.md
+    
+    private static let lowerBoundKeyword = "<!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
+    private static let upperBoundKeyword = "<!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
+    public static func writeToREADME(repositories: [GitHubRepository]) throws {
+        let (url, string, lowerBound, upperBound) = try readFromREADME()
+        let outputListOfRepositoriesString = """
+        \(lowerBoundKeyword)
+        |名前|リポジトリ|スター数|ウォッチ数|
+        |:--|:--|:--|:--|
+        
+        """
+        + repositories.map {
+            let repository = "\($0.owner)/\($0.repository)"
+            return "|\($0.name)|[\(repository)](https://github.com/\(repository))|[![GitHub Repo stars](https://img.shields.io/github/stars/\(repository)?style=social)](https://github.com/\(repository)/stargazers)|[![GitHub watchers](https://img.shields.io/github/watchers/\(repository)?style=social)](https://github.com/\(repository)/watchers)|\n"
+        }.joined()
+        + upperBoundKeyword
+        try string.replacingCharacters(in: lowerBound..<upperBound, with: outputListOfRepositoriesString)
+            .write(to: url, atomically: true, encoding: .utf8)
+    }
+    
+    static func readFromREADME() throws -> (URL, String, String.Index, String.Index) {
+        let url = URL.topLevelDirectory.appendingPathComponent("README.md")
+        let string = try String(contentsOf: url)
+        guard let lowerBound = string.range(of: lowerBoundKeyword)?.lowerBound,
+              let upperBound = string.range(of: upperBoundKeyword)?.upperBound else {
+            throw Error.invalidREADMEFormat
+        }
+        return (url, string, lowerBound, upperBound)
     }
 }

--- a/Sources/ReleaseSubscriptionsCore/FileHelper.swift
+++ b/Sources/ReleaseSubscriptionsCore/FileHelper.swift
@@ -36,11 +36,7 @@ public struct FileHelper {
     
     static var outputURL: URL {
         get throws {
-            let outputURL = URL(fileURLWithPath: #filePath)
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .appendingPathComponent("Outputs", isDirectory: true)
+            let outputURL = URL.topLevelDirectory.appendingPathComponent("Outputs", isDirectory: true)
             if !manager.fileExists(atPath: outputURL.path) {
                 try manager.createDirectory(at: outputURL, withIntermediateDirectories: true)
             }

--- a/Sources/ReleaseSubscriptionsCore/Parser.swift
+++ b/Sources/ReleaseSubscriptionsCore/Parser.swift
@@ -11,15 +11,12 @@ import Yaml
 public struct Parser {
     enum Error: Swift.Error {
         case invalidYamlFormat
+        case invalidREADMEFormat
         case unknownCase
     }
     
     public static func parse() throws -> [GitHubRepository] {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("ReleaseSubscriptions.yml")
+        let url = URL.topLevelDirectory.appendingPathComponent("ReleaseSubscriptions.yml")
         let string = try String(contentsOf: url)
         let yaml = try Yaml.load(string)
         guard let repositoriesYaml = yaml["repositories"].array else {
@@ -43,5 +40,29 @@ public struct Parser {
                 throw Error.unknownCase
             }
         }
+    }
+    
+    public static func writeToREADME(repositories: [GitHubRepository]) throws {
+        let lowerBoundKeyword = "<!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
+        let upperBoundKeyword = "<!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
+        let url = URL.topLevelDirectory.appendingPathComponent("README.md")
+        var string = try String(contentsOf: url)
+        guard let lowerBound = string.range(of: lowerBoundKeyword)?.lowerBound,
+              let upperBound = string.range(of: upperBoundKeyword)?.upperBound else {
+            throw Error.invalidREADMEFormat
+        }
+        let outputListOfRepositoriesString = """
+        \(lowerBoundKeyword)
+        |名前|リポジトリ|スター数|ウォッチ数|
+        |:--|:--|:--|:--|
+        
+        """
+        + repositories.map {
+            let repository = "\($0.owner)/\($0.repository)"
+            return "|\($0.name)|[\(repository)](https://github.com/\(repository))|[![GitHub Repo stars](https://img.shields.io/github/stars/\(repository)?style=social)](https://github.com/\(repository)/stargazers)|[![GitHub watchers](https://img.shields.io/github/watchers/\(repository)?style=social)](https://github.com/\(repository)/watchers)|\n"
+        }.joined()
+        + upperBoundKeyword
+        string.replaceSubrange(lowerBound..<upperBound, with: outputListOfRepositoriesString)
+        try string.write(to: url, atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/ReleaseSubscriptionsCore/Parser.swift
+++ b/Sources/ReleaseSubscriptionsCore/Parser.swift
@@ -11,7 +11,6 @@ import Yaml
 public struct Parser {
     enum Error: Swift.Error {
         case invalidYamlFormat
-        case invalidREADMEFormat
         case unknownCase
     }
     
@@ -40,29 +39,5 @@ public struct Parser {
                 throw Error.unknownCase
             }
         }
-    }
-    
-    public static func writeToREADME(repositories: [GitHubRepository]) throws {
-        let lowerBoundKeyword = "<!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
-        let upperBoundKeyword = "<!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
-        let url = URL.topLevelDirectory.appendingPathComponent("README.md")
-        var string = try String(contentsOf: url)
-        guard let lowerBound = string.range(of: lowerBoundKeyword)?.lowerBound,
-              let upperBound = string.range(of: upperBoundKeyword)?.upperBound else {
-            throw Error.invalidREADMEFormat
-        }
-        let outputListOfRepositoriesString = """
-        \(lowerBoundKeyword)
-        |名前|リポジトリ|スター数|ウォッチ数|
-        |:--|:--|:--|:--|
-        
-        """
-        + repositories.map {
-            let repository = "\($0.owner)/\($0.repository)"
-            return "|\($0.name)|[\(repository)](https://github.com/\(repository))|[![GitHub Repo stars](https://img.shields.io/github/stars/\(repository)?style=social)](https://github.com/\(repository)/stargazers)|[![GitHub watchers](https://img.shields.io/github/watchers/\(repository)?style=social)](https://github.com/\(repository)/watchers)|\n"
-        }.joined()
-        + upperBoundKeyword
-        string.replaceSubrange(lowerBound..<upperBound, with: outputListOfRepositoriesString)
-        try string.write(to: url, atomically: true, encoding: .utf8)
     }
 }

--- a/Tests/ReleaseSubscriptionsCoreTests/ReleaseSubscriptionsCoreTests.swift
+++ b/Tests/ReleaseSubscriptionsCoreTests/ReleaseSubscriptionsCoreTests.swift
@@ -14,6 +14,10 @@ final class ReleaseSubscriptionsCoreTests: XCTestCase {
         dump(repositories)
     }
     
+    func testREADMELoading() throws {
+        _ = try FileHelper.readFromREADME()
+    }
+    
     func testPastOutputsLoading() throws {
         let repositories = try Parser.parse()
         let oldContents = try FileHelper.load(repositories: repositories)


### PR DESCRIPTION
close #1

`README.md` にリリース情報自動取得対象のリポジトリ一覧を追加する。

`README.md` にあらかじめ `<!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->` `<!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->` を置いておき、[Scheduled Run `scheduled.yml`](https://github.com/ios-osushi/release-subscriptions/blob/main/.github/workflows/scheduled.yml) が実行される際に `README.md` も自動更新されるようにする。

## スクリーンショット
![Web キャプチャ_19-4-2022_12748_github com](https://user-images.githubusercontent.com/13805382/163845989-21d3cf62-ae29-41cd-aadf-90d0b75a5a7b.jpeg)