### PR TITLE
ID が重複したものが JSON に残ってしまうことの修正

### DIFF
--- a/Sources/ReleaseSubscriptions/App.swift
+++ b/Sources/ReleaseSubscriptions/App.swift
@@ -33,7 +33,7 @@ struct App: AsyncParsableCommand {
             let repositories = try Parser.parse()
             let oldContents = try FileHelper.load(repositories: repositories)
             let newContents = try await Fetcher.fetch(repositories: repositories)
-            let combinedContents = oldContents.merging(newContents) { Set($0 + $1).sorted() }
+            let combinedContents = oldContents.merging(newContents) { ($0 + $1).identified().sorted() }
             let updatedContents = DifferenceComparator.insertions(repositories: repositories, old: oldContents, new: combinedContents)
             try await SlackNotifier.notify(to: slackURLs(), updates: updatedContents)
             try FileHelper.save(contents: combinedContents)

--- a/Sources/ReleaseSubscriptionsCore/Extension.swift
+++ b/Sources/ReleaseSubscriptionsCore/Extension.swift
@@ -41,3 +41,13 @@ public extension URLSession {
         }
     }
 }
+
+public extension Array where Element: Identifiable {
+    func identified() -> Self {
+        var ids: Set<Element.ID> = []
+        return filter { element in
+            let (inserted, _) = ids.insert(element.id)
+            return inserted
+        }
+    }
+}


### PR DESCRIPTION
もともと `Hashable` に準拠させ、 `Set` に変換することで表現していましたが、 ID で unique にするために `identified` を生やして修正しました。