### PR TITLE
Slack API に流す body の文字数を制限する

### DIFF
--- a/Sources/ReleaseSubscriptionsCore/SlackNotifier.swift
+++ b/Sources/ReleaseSubscriptionsCore/SlackNotifier.swift
@@ -92,7 +92,7 @@ public struct SlackNotifier {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\(body.isEmpty ? " " : body)"
+                    "text": "\(body.isEmpty ? " " : String(body.prefix(2500)))"
                 }
             }
         ]


### PR DESCRIPTION
Scheduled Run [#700](https://github.com/ios-osushi/release-subscriptions/actions/runs/4825786299)、[#701](https://github.com/ios-osushi/release-subscriptions/actions/runs/4835930010)、[#702](https://github.com/ios-osushi/release-subscriptions/actions/runs/4841579647) の失敗原因は、[Quick/Quick の v7.0.0-beta.3 のリリースノート](https://github.com/Quick/Quick/releases/tag/v7.0.0-beta.3) の文字列長が非常に長く、それをそのまま Slack API に流し込もうとして HTTP 400 が返ってきてしまったことと推測される。

Slack API に送信するリリースノートの `body` をよしなな長さにトリムする。