### PR TITLE
feat(log): move finished log

### DIFF
--- a/Sources/ReleaseSubscriptions/App.swift
+++ b/Sources/ReleaseSubscriptions/App.swift
@@ -19,9 +19,6 @@ struct App: AsyncParsableCommand {
     var secondarySlackURL: URL?
     
     func run() async throws {
-        defer {
-            Logger.app.info("🎉 \(#function) finished")
-        }
         Logger.app.info("ℹ️ \(#function) started")
         do {
             if primarySlackURL == nil {
@@ -38,6 +35,7 @@ struct App: AsyncParsableCommand {
             try await SlackNotifier.notify(to: slackURLs(), updates: updatedContents)
             try FileHelper.save(contents: combinedContents)
             try FileHelper.writeToREADME(repositories: repositories)
+            Logger.app.info("🎉 \(#function) finished")
         } catch {
             Logger.app.error("❌ \(error)")
             throw error

--- a/Sources/ReleaseSubscriptionsCore/DifferenceComparator.swift
+++ b/Sources/ReleaseSubscriptionsCore/DifferenceComparator.swift
@@ -10,9 +10,6 @@ import Logging
 
 public struct DifferenceComparator {
     public static func insertions(repositories: [GitHubRepository], old: [GitHubRepository : [Release]], new: [GitHubRepository : [Release]]) -> [GitHubRepository : [Release]] {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         var insertions: [GitHubRepository : [Release]] = [:]
         for repository in repositories {
@@ -34,6 +31,7 @@ public struct DifferenceComparator {
                 Logger.shared.info("🤩 There are differences in \(repository.name) releases")
             }
         }
+        Logger.shared.info("🎉 \(#function) finished")
         return insertions
     }
 }

--- a/Sources/ReleaseSubscriptionsCore/Fetcher.swift
+++ b/Sources/ReleaseSubscriptionsCore/Fetcher.swift
@@ -28,9 +28,6 @@ public struct Fetcher {
     }
     
     public static func fetch(repositories: [GitHubRepository]) async throws -> [GitHubRepository : [Release]] {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         return try await withThrowingTaskGroup(of: (GitHubRepository, [Release]).self) { group in
             for repository in repositories {
@@ -44,6 +41,7 @@ public struct Fetcher {
             for try await (repository, releases) in group {
                 results[repository] = releases
             }
+            Logger.shared.info("🎉 \(#function) finished")
             return results
         }
     }

--- a/Sources/ReleaseSubscriptionsCore/FileHelper.swift
+++ b/Sources/ReleaseSubscriptionsCore/FileHelper.swift
@@ -52,9 +52,6 @@ public struct FileHelper {
     // MARK: - Repositories and Releases
     
     public static func load(repositories: [GitHubRepository]) throws -> [GitHubRepository : [Release]] {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         var contents: [GitHubRepository : [Release]] = [:]
         for repository in repositories {
@@ -71,13 +68,11 @@ public struct FileHelper {
                 Logger.shared.info("🔔 \(repository.outputJSONFileName) loading was skipped because that file could not be found")
             }
         }
+        Logger.shared.info("🎉 \(#function) finished")
         return contents
     }
     
     public static func save(contents: [GitHubRepository : [Release]]) throws {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         for (repository, releases) in contents {
             Logger.shared.info("ℹ️ Saving \(repository.outputJSONFileName)")
@@ -86,17 +81,14 @@ public struct FileHelper {
             try data.write(to: url)
             Logger.shared.info("✅ Saved \(repository.outputJSONFileName)")
         }
+        Logger.shared.info("🎉 \(#function) finished")
     }
-    
     
     // MARK: - README.md
     
     private static let lowerBoundKeyword = "<!-- BEGIN LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
     private static let upperBoundKeyword = "<!-- END LIST OF REPOSITORIES (AUTOMATICALLY OUTPUT) -->"
     public static func writeToREADME(repositories: [GitHubRepository]) throws {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         let (url, string, lowerBound, upperBound) = try readFromREADME()
         let outputListOfRepositoriesString = """
@@ -112,12 +104,10 @@ public struct FileHelper {
         + upperBoundKeyword
         try string.replacingCharacters(in: lowerBound..<upperBound, with: outputListOfRepositoriesString)
             .write(to: url, atomically: true, encoding: .utf8)
+        Logger.shared.info("🎉 \(#function) finished")
     }
     
     static func readFromREADME() throws -> (URL, String, String.Index, String.Index) {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         let url = URL.topLevelDirectory.appendingPathComponent("README.md")
         let string = try String(contentsOf: url)
@@ -125,6 +115,7 @@ public struct FileHelper {
               let upperBound = string.range(of: upperBoundKeyword)?.upperBound else {
             throw Error.invalidREADMEFormat
         }
+        Logger.shared.info("🎉 \(#function) finished")
         return (url, string, lowerBound, upperBound)
     }
 }

--- a/Sources/ReleaseSubscriptionsCore/Parser.swift
+++ b/Sources/ReleaseSubscriptionsCore/Parser.swift
@@ -16,9 +16,6 @@ public struct Parser {
     }
     
     public static func parse() throws -> [GitHubRepository] {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         let url = URL.topLevelDirectory.appendingPathComponent("ReleaseSubscriptions.yml")
         let string = try String(contentsOf: url)
@@ -39,9 +36,11 @@ public struct Parser {
             switch `case` {
             case "releases":
                 Logger.shared.info("✅ The correct YAML format: \(name) (\(`case`))")
+                Logger.shared.info("🎉 \(#function) finished")
                 return .releases(destination, .init(name: name, owner: owner, repository: repository))
             case "tags":
                 Logger.shared.info("✅ The correct YAML format: \(name) (\(`case`))")
+                Logger.shared.info("🎉 \(#function) finished")
                 return .tags(destination, .init(name: name, owner: owner, repository: repository))
             default:
                 throw Error.unknownCase

--- a/Sources/ReleaseSubscriptionsCore/SlackNotifier.swift
+++ b/Sources/ReleaseSubscriptionsCore/SlackNotifier.swift
@@ -28,9 +28,6 @@ public struct SlackNotifier {
     }()
     
     public static func notify(to slackURLs: [SlackWebhookDestination : URL], updates: [GitHubRepository : [Release]]) async throws {
-        defer {
-            Logger.shared.info("🎉 \(#function) finished")
-        }
         Logger.shared.info("ℹ️ \(#function) started")
         try await withThrowingTaskGroup(of: Void.self) { group in
             for (repository, releases) in updates {
@@ -60,6 +57,7 @@ public struct SlackNotifier {
             }
             try await group.waitForAll()
         }
+        Logger.shared.info("🎉 \(#function) finished")
     }
     
     static private func message(name: String, owner: String, repo: String, repoURL: URL, title: String, version: String, releaseURL: URL, publishedAt: String?, body: String) -> String {


### PR DESCRIPTION
`defer` でログを出力すると、スロー時にも実行されてどこで処理が失敗したかわかりづらいので、各関数の最後に呼ぶようにした。