### PR TITLE
fix: XcodesApp org name

### DIFF
--- a/ReleaseSubscriptions.yml
+++ b/ReleaseSubscriptions.yml
@@ -313,7 +313,7 @@ repositories:
   - kind: secondary
     case: releases
     name: Xcodes.app
-    owner: RobotsAndPencils
+    owner: XcodesOrg
     repo: XcodesApp
   
   - kind: secondary


### PR DESCRIPTION
- release の slack 通知が失敗していることの原因。 Transfer されると redirect されるが、その際に API Limit がかかるようになってしまう