### PR TITLE
アクセストークンとともにリポジトリ情報を取得する

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -26,7 +26,7 @@ jobs:
           ${{ runner.os }}-spm-
     - name: Run releaseSubscriptions
       run: |
-        swift run -c release releaseSubscriptions --primary-slack-url ${{ secrets.SLACK_WEBHOOK_PRIMARY_URL }} --secondary-slack-url ${{ secrets.SLACK_WEBHOOK_SECONDARY_URL }}
+        swift run -c release releaseSubscriptions --access-token ${{ secrets.RELEASE_SUBSCRIPTIONS_FINE_GRAINED_PAT }} --primary-slack-url ${{ secrets.SLACK_WEBHOOK_PRIMARY_URL }} --secondary-slack-url ${{ secrets.SLACK_WEBHOOK_SECONDARY_URL }}
     - name: Commit and push if needed
       run: |
         git config user.name github-actions[bot]

--- a/Sources/ReleaseSubscriptionsCore/Fetcher.swift
+++ b/Sources/ReleaseSubscriptionsCore/Fetcher.swift
@@ -18,11 +18,18 @@ public struct Fetcher {
         return decoder
     }()
     
-    static func fetch(repository: GitHubRepository) async throws -> [Release] {
+    static func fetch(repository: GitHubRepository, accessToken: String?) async throws -> [Release] {
         do {
             Logger.shared.info("ℹ️ Fetching \(repository.apiURL)")
             let url = repository.apiURL
-            let (data, _) = try await URLSession.shared.data(from: url)
+            var request = URLRequest(url: url)
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+            if let accessToken {
+                request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+                Logger.shared.info("ℹ️ Set bearer token")
+            }
+            let (data, _) = try await URLSession.shared.data(for: request)
             do {
                 Logger.shared.info("✅ Fetched \(repository.apiURL)")
                 let releases = try decoder.decode([Release].self, from: data)
@@ -38,7 +45,7 @@ public struct Fetcher {
         }
     }
     
-    public static func fetch(repositories: [GitHubRepository]) async throws -> [GitHubRepository : [Release]] {
+    public static func fetch(repositories: [GitHubRepository], accessToken: String?) async throws -> [GitHubRepository : [Release]] {
         defer {
             Logger.shared.info("🎉 \(#function) finished")
         }
@@ -47,7 +54,7 @@ public struct Fetcher {
             for repository in repositories {
                 group.addTask {
                     do {
-                        let releases = try await fetch(repository: repository)
+                        let releases = try await fetch(repository: repository, accessToken: accessToken)
                         return (repository, releases)
                     } catch {
                         Logger.shared.error("❌ \(#function) failed")

--- a/Sources/ReleaseSubscriptionsCore/Fetcher.swift
+++ b/Sources/ReleaseSubscriptionsCore/Fetcher.swift
@@ -19,12 +19,23 @@ public struct Fetcher {
     }()
     
     static func fetch(repository: GitHubRepository) async throws -> [Release] {
-        Logger.shared.info("ℹ️ Fetching \(repository.apiURL)")
-        let url = repository.apiURL
-        let (data, _) = try await URLSession.shared.data(from: url)
-        let releases = try decoder.decode([Release].self, from: data)
-        Logger.shared.info("✅ Fetched \(repository.apiURL)")
-        return releases
+        do {
+            Logger.shared.info("ℹ️ Fetching \(repository.apiURL)")
+            let url = repository.apiURL
+            let (data, _) = try await URLSession.shared.data(from: url)
+            do {
+                Logger.shared.info("✅ Fetched \(repository.apiURL)")
+                let releases = try decoder.decode([Release].self, from: data)
+                Logger.shared.info("✅ Parsed \(repository.apiURL)")
+                return releases
+            } catch {
+                Logger.shared.info("❌ Parse failed \(repository.apiURL), error: \(error), data: \(String(data: data, encoding: .utf8) ?? "nil")")
+                throw error
+            }
+        } catch {
+            Logger.shared.info("❌ Fetch failed \(repository.apiURL), error: \(error)")
+            throw error
+        }
     }
     
     public static func fetch(repositories: [GitHubRepository]) async throws -> [GitHubRepository : [Release]] {


### PR DESCRIPTION
購読するリポジトリが増えてきた影響で、`Fetcher.fetch(repository:)` にて GitHub からリポジトリ情報を取得しようとした際、API 上限に引っかかってしまって失敗するようになってしまった。

GitHub アクセストークンを用いたアクセスを行うことでこの API 上限が緩和されるため、それを用いるようにする。

（ただ 依然として数が多いので、再実行を繰り返すと API 上限に再び引っかかったりする😢）